### PR TITLE
ada backup list: Fix truncated messages via Snippet when more than 250 backups

### DIFF
--- a/src/hostinger.coffee
+++ b/src/hostinger.coffee
@@ -63,7 +63,16 @@ module.exports = (robot) ->
            array = []
            for backup in result
              array.push "#{backup.type} (preparing: #{backup.preparing}) : #{backup.name} (#{backup.size}) - #{backup.url} (link is clickable one time only)"
-           msg.send array.join("\n")
+           if array.length > 250
+             filename = "backuplist.txt"
+             opts = {
+             content: array.join("\n")
+             title: 'Backup List'
+             channels: msg.message.room
+             }
+             robot.adapter.client.web.files.upload(filename, opts)
+           else
+             msg.send array.join("\n")
         else
           msg.send "no backups for #{username}"
 


### PR DESCRIPTION
Cannot list backups for this account because it has **1987 backups** 
`hubot[21279]: warn: message_truncated`

```
ada hostinger backup list u884116840
```
If more than 250 backups, send a response in Snippet

Closes: https://github.com/hostinger/monitoring/issues/512